### PR TITLE
Remove bl mpi

### DIFF
--- a/hydra_pspec/pspec.py
+++ b/hydra_pspec/pspec.py
@@ -559,12 +559,12 @@ def gibbs_sample_with_fg(
             # Write current set of samples to disk
             utils.write_numpy_files(
                 out_dir,
-                signal_cr,
-                signal_S,
-                signal_ps,
-                fg_amps,
-                chisq,
-                ln_post
+                signal_cr[:i+1],
+                signal_S[:i+1],
+                signal_ps[:i+1],
+                fg_amps[:i+1],
+                chisq[:i+1],
+                ln_post[:i+1]
             )
     
     if out_dir is not None and Niter % write_Niter > 0:

--- a/run-hydra-pspec.py
+++ b/run-hydra-pspec.py
@@ -23,29 +23,14 @@ from hydra_pspec.utils import (
     add_mtime_to_filepath
 )
 
-try:
-    from mpi4py import MPI
-
-    HAVE_MPI = True
-    comm = MPI.COMM_WORLD
-    size = comm.Get_size()
-    rank = comm.Get_rank()
-except ImportError:
-    HAVE_MPI = False
-    # This can be made more robust
-    import sys
-    print("This script requires MPI.  Exiting.")
-    sys.exit()
-
 
 parser = ArgumentParser()
 parser.add_argument(
     "--ant_str",
     type=str,
     default="cross",
-    help="Comma delimited list of antenna pairs joined by underscores, e.g. "
-         "'1_11,12_14'.  Used via the `ant_str` kwarg in "
-         "`pyuvdata.UVData.select`."
+    help="Antenna pair joined by an underscore, e.g. '1_11' or '12_14'.  Used "
+         "via the `ant_str` kwarg in `pyuvdata.UVData.select`."
 )
 parser.add_argument(
     "--sigcov0",
@@ -92,7 +77,9 @@ parser.add_argument(
     type=str,
     help="Path to a single file or a directory containing per-baseline flags. "
          "Files must be readable by `np.load` and must have the same shape as "
-         "the visibilities for a single baseline being analyzed."
+         "the visibilities for a single baseline being analyzed.  The flags "
+         "must be a boolean array where True and False correspond to flagged "
+         "(unused) and unflagged (used) data, respectively."
 )
 parser.add_argument(
     "--flags_file",
@@ -194,9 +181,8 @@ parser.add_argument(
 parser.add_argument(
     "--Nproc",
     type=int,
-    default=0,
-    help="Number of threads per MPI process.  Defaults to the maximum number "
-         "of cores available divided by the number of baselines."
+    default=1,
+    help="Number of multiprocess threads.  Defaults to 1."
 )
 parser.add_argument(
     "--out_dir",
@@ -265,178 +251,148 @@ def check_load_path(fp):
             return fp_is_dir, data
 
 
-if rank == 0:
-    if "config" in args.__dict__:
-        print(f"Loading config file {str(args.config[0])}", end="\n\n")
-    pprint(args.__dict__)
 
-    if not args.file_paths:
-        # Load example data from HERA PSpec
-        from hera_pspec.data import DATA_PATH
-        dfiles = ["zen.2458042.12552.xx.HH.uvXAA"]
-        file_paths = [os.path.join(DATA_PATH, df) for df in dfiles[:1]]
-    else:
-        file_paths = sorted([Path(fp) for fp in args.file_paths])
-    nfiles = len(file_paths)
-    print(f"\nReading {nfiles} file(s)")
+if "config" in args.__dict__:
+    print(f"Loading config file {str(args.config[0])}", end="\n\n")
+pprint(args.__dict__)
 
-    uvd = UVData()
-    if args.freq_range:
-        uvd.read(file_paths[0], read_data=False)
-        # uvd.freq_array[0] might not work with future versions of pyuvdata
-        freqs_in = Quantity(uvd.freq_array[0], unit="Hz")
-        freqs_to_keep = filter_freqs(args.freq_range, freqs_in)
-        freqs_to_keep = freqs_to_keep.to("Hz").value
-    else:
-        freqs_to_keep = None
-    uvd.read(file_paths, ant_str=args.ant_str, frequencies=freqs_to_keep)
-    uvd.conjugate_bls()
-    if args.file_paths:
-        uvd = form_pseudo_stokes_vis(uvd)
-    # Assuming for now that size == Nbls
-    antpairs = uvd.get_antpairs()[:size]
-    Nbls = len(antpairs)
-
-    freqs = Quantity(uvd.freq_array[0], unit="Hz")
-    freq_str = (
-        f"{freqs.min().to('MHz').value:.3f}-"
-        + f"{freqs.max().to('MHz').value:.3f}MHz"
-    )
-
-    if args.Nproc == 0:
-        ncores = len(os.sched_getaffinity(0))  # number of cores available
-        nproc = ncores // Nbls  # number of cores per MPI task
-        if nproc == 0:
-            nproc = 1
-    else:
-        nproc = args.Nproc
-    print(f"\nnproc = {nproc}")
-
-    bl_data_shape = (uvd.Ntimes, uvd.Nfreqs)
-    cov_ff_shape = (uvd.Nfreqs, uvd.Nfreqs)
-    if args.flags:
-        flags_path = Path(args.flags)
-        flags_path_is_dir, flags = check_load_path(flags_path)
-        if not flags_path_is_dir:
-            check_shape(flags.shape, bl_data_shape, desc="flags")
-    if args.noise:
-        noise_path = Path(args.noise)
-        noise_path_is_dir, noise = check_load_path(noise_path)
-        if not noise_path_is_dir:
-            check_shape(noise.shape, bl_data_shape, desc="noise")
-    if args.nsamples:
-        nsamples_path = Path(args.nsamples)
-        nsamples_path_is_dir, nsamples = check_load_path(nsamples_path)
-        if not nsamples_path_is_dir:
-            check_shape(nsamples.shape, bl_data_shape, desc="nsamples")
-    if args.sigcov0:
-        sigcov0_path = Path(args.sigcov0)
-        sigcov0_path_is_dir, sigcov0 = check_load_path(sigcov0_path)
-        if not sigcov0_path_is_dir:
-            check_shape(sigcov0.shape, cov_ff_shape, desc="signal covariance")
-    if args.noise_cov:
-        noise_cov_path = Path(args.noise_cov)
-        noise_cov_path_is_dir, noise_cov = check_load_path(noise_cov_path)
-        if not noise_cov_path_is_dir:
-            check_shape(noise_cov.shape, cov_ff_shape, desc="noise covariance")
-
-    if args.fg_eig_dir:
-        fg_eig_dir = Path(args.fg_eig_dir)
-    all_data_weights = []
-    for i_bl, antpair in enumerate(antpairs):
-        bl_str = f"{antpair[0]}-{antpair[1]}"
-
-        if args.fg_eig_dir:
-            # fgmodes has shape (Nfreqs, Nfgmodes)
-            if not args.fg_eig_file:
-                fgmodes_path = fg_eig_dir / bl_str / f"evecs-{freq_str}.npy"
-            else:
-                fgmodes_path = fg_eig_dir / bl_str / args.fg_eig_file
-            fgmodes = np.load(fgmodes_path)
-            fgmodes = fgmodes[:, :args.Nfgmodes]
-        else:
-            # Generate approximate set of FG modes from Legendre polynomials
-            fgmodes = np.array([
-                scipy.special.legendre(i)(np.linspace(-1., 1., freqs.size))
-                for i in range(args.Nfgmodes)
-            ]).T
-        
-        if args.sigcov0 and sigcov0_path_is_dir:
-            bl_sigcov0_path = sigcov0_path / bl_str / args.sigcov0_file
-            sigcov0 = np.load(bl_sigcov0_path)
-            check_shape(
-                sigcov0.shape, cov_ff_shape,
-                desc=f"signal covariance ({bl_str})"
-            )
-        if args.noise_cov and noise_cov_path_is_dir:
-            bl_noise_cov_path = noise_cov_path / bl_str / args.noise_cov_file
-            noise_cov = np.load(bl_noise_cov_path)
-            check_shape(
-                noise_cov.shape, cov_ff_shape,
-                desc=f"noise covariance ({bl_str})"
-            )
-        
-        d = uvd.get_data(antpair + ("xx",), force_copy=True)
-        if args.flags and flags_path_is_dir:
-            bl_flags_path = flags_path / bl_str / args.flags_file
-            flags = np.load(bl_flags_path)
-            check_shape(flags.shape, d.shape, desc=f"flags ({bl_str})")
-        elif not args.flags:
-            flags = uvd.get_flags(antpair + ("xx",))
-
-        if args.nsamples and nsamples_path_is_dir:
-            bl_nsamples_path = nsamples_path / bl_str / args.nsamples_file
-            nsamples = np.load(bl_nsamples_path)
-            check_shape(nsamples.shape, d.shape, desc=f"nsamples ({bl_str})")
-        else:
-            nsamples = None
-
-        if args.noise and noise_path_is_dir:
-            bl_noise_path = noise_path / bl_str / args.noise_file
-            noise = np.load(bl_noise_path)
-            check_shape(noise.shape, d.shape, desc=f"noise ({bl_str})")
-            if nsamples is not None:
-                noise /= np.sqrt(nsamples)
-            d += noise
-
-        bl_data_weights = {
-            "bl": antpair,
-            "d": d,
-            "w": flags,
-            "fgmodes": fgmodes,
-            "freq_str": freq_str,
-            "nproc": nproc
-        }
-        if args.sigcov0:
-            bl_data_weights["S_initial"] = sigcov0
-        if args.noise_cov:
-            bl_data_weights["N"] = noise_cov
-        all_data_weights.append(bl_data_weights)
+if not args.file_paths:
+    print('Must pass file(s) to analyze via --file_paths.  Exiting.')
+    sys.exit()
 else:
-    all_data_weights = None
+    file_paths = sorted([Path(fp) for fp in args.file_paths])
+nfiles = len(file_paths)
+print(f"\nReading {nfiles} file(s)")
 
-# Send per-baseline visibilities to each process
-data = comm.scatter(all_data_weights)
-bl = data["bl"]
-d = data["d"]
-w = ~data["w"]
-fgmodes = data["fgmodes"]
-freq_str = data["freq_str"]
-nproc = data["nproc"]
-
-Ntimes, Nfreqs = d.shape
-
-# Initial guess at EoR power spectrum
-if "S_initial" in data:
-    S_initial = data["S_initial"]
+uvd = UVData()
+if args.freq_range:
+    uvd.read(file_paths[0], read_data=False)
+    freqs_in = uvd.freq_array
+    if not uvd.use_future_array_shapes:
+        # Remove the Nspws axis
+        freqs_in = freqs_in[0]
+    freqs_in = Quantity(freqs_in, unit="Hz")
+    freqs_to_keep = filter_freqs(args.freq_range, freqs_in)
+    freqs_to_keep = freqs_to_keep.to("Hz").value
 else:
-    S_initial = np.eye(Nfreqs)
+    freqs_to_keep = None
+uvd.read(file_paths, ant_str=args.ant_str, frequencies=freqs_to_keep)
+uvd.conjugate_bls()
+if args.file_paths:
+    # Sum XX and YY polarizations to obtain pseudo-Stokes I (pI) visibilities
+    # and store them in the XX polarization
+    uvd = form_pseudo_stokes_vis(uvd)
+antpair = uvd.get_antpairs()[0]
+bl_str = f"{antpair[0]}-{antpair[1]}"
+Ntimes = uvd.Ntimes
+Nfreqs = uvd.Nfreqs
 
-if "N" in data:
-    Ninv = np.linalg.inv(data["N"])
+freqs = uvd.freq_array
+if not uvd.use_future_array_shapes:
+    freqs = freqs[0]
+freqs = Quantity(freqs, unit="Hz")
+freq_str = (
+    f"{freqs.min().to('MHz').value:.3f}-"
+    + f"{freqs.max().to('MHz').value:.3f}MHz"
+)
+
+bl_data_shape = (Ntimes, Nfreqs)
+cov_ff_shape = (Nfreqs, Nfreqs)
+if args.flags:
+    flags_path = Path(args.flags)
+    flags_path_is_dir, flags = check_load_path(flags_path)
+    if not flags_path_is_dir:
+        check_shape(flags.shape, bl_data_shape, desc="flags")
+if args.noise:
+    noise_path = Path(args.noise)
+    noise_path_is_dir, noise = check_load_path(noise_path)
+    if not noise_path_is_dir:
+        check_shape(noise.shape, bl_data_shape, desc="noise")
+if args.nsamples:
+    nsamples_path = Path(args.nsamples)
+    nsamples_path_is_dir, nsamples = check_load_path(nsamples_path)
+    if not nsamples_path_is_dir:
+        check_shape(nsamples.shape, bl_data_shape, desc="nsamples")
+if args.sigcov0:
+    sigcov0_path = Path(args.sigcov0)
+    sigcov0_path_is_dir, sigcov0 = check_load_path(sigcov0_path)
+    if not sigcov0_path_is_dir:
+        check_shape(sigcov0.shape, cov_ff_shape, desc="signal covariance")
+if args.noise_cov:
+    noise_cov_path = Path(args.noise_cov)
+    noise_cov_path_is_dir, noise_cov = check_load_path(noise_cov_path)
+    if not noise_cov_path_is_dir:
+        check_shape(noise_cov.shape, cov_ff_shape, desc="noise covariance")
+if args.fg_eig_dir:
+    fg_eig_dir = Path(args.fg_eig_dir)
+
+if args.fg_eig_dir:
+    # fgmodes has shape (Nfreqs, Nfgmodes)
+    if not args.fg_eig_file:
+        # Look for a file with the default filename from
+        # hydra-pspec/scripts/calc-vis-cov-matrices.py
+        fgmodes_path = fg_eig_dir / bl_str / f"evecs-{freq_str}.npy"
+    else:
+        fgmodes_path = fg_eig_dir / bl_str / args.fg_eig_file
+    fgmodes = np.load(fgmodes_path)
+    fgmodes = fgmodes[:, :args.Nfgmodes]
 else:
-    # Simple guess for noise variance
+    # Generate approximate set of FG modes from Legendre polynomials
+    fgmodes = np.array([
+        scipy.special.legendre(i)(np.linspace(-1., 1., freqs.size))
+        for i in range(args.Nfgmodes)
+    ]).T
+
+if args.sigcov0:
+    if sigcov0_path_is_dir:
+        bl_sigcov0_path = sigcov0_path / bl_str / args.sigcov0_file
+        sigcov0 = np.load(bl_sigcov0_path)
+        check_shape(
+            sigcov0.shape, cov_ff_shape, desc=f"signal covariance ({bl_str})"
+        )
+else:
+    sigcov0 = np.eye(Nfreqs)
+
+if args.noise_cov:
+    if noise_cov_path_is_dir:
+        bl_noise_cov_path = noise_cov_path / bl_str / args.noise_cov_file
+        noise_cov = np.load(bl_noise_cov_path)
+        check_shape(
+            noise_cov.shape, cov_ff_shape, desc=f"noise covariance ({bl_str})"
+        )
+    Ninv = np.linalg.inv(noise_cov)
+else:
     Ninv = np.eye(Nfreqs)
+
+# pI visibilities stored in the XX polarization
+d = uvd.get_data(antpair + ("xx",), force_copy=True)
+if args.flags:
+    if flags_path_is_dir:
+        bl_flags_path = flags_path / bl_str / args.flags_file
+        flags = np.load(bl_flags_path)
+        check_shape(flags.shape, d.shape, desc=f"flags ({bl_str})")
+else:
+    # FIXME: there is nothing currently in place to handle flags which differ
+    # between XX and YY polarizations in `form_pseudo_stokes_vis`.  Differing
+    # flags should be accounted for in the future, possibly via Nsamples.
+    flags = uvd.get_flags(antpair + ("xx",))
+
+if args.nsamples:
+    if nsamples_path_is_dir:
+        bl_nsamples_path = nsamples_path / bl_str / args.nsamples_file
+        nsamples = np.load(bl_nsamples_path)
+        check_shape(nsamples.shape, d.shape, desc=f"nsamples ({bl_str})")
+else:
+    nsamples = None
+
+if args.noise:
+    if noise_path_is_dir:
+        bl_noise_path = noise_path / bl_str / args.noise_file
+        noise = np.load(bl_noise_path)
+        check_shape(noise.shape, d.shape, desc=f"noise ({bl_str})")
+    if nsamples is not None:
+        noise /= np.sqrt(nsamples)
+    d += noise
 
 # Power spectrum prior
 # This has shape (2, Ndelays). The first dimension is for the upper and
@@ -464,7 +420,7 @@ else:
 if out_dir.exists() and not args.clobber:
     # Check for existing output files to avoid overwriting if clobber=False
     add_mtime_to_filepath(out_dir)
-out_dir /= f"{bl[0]}-{bl[1]}"
+out_dir /= bl_str
 out_dir.mkdir(exist_ok=True, parents=True)
 # Catalog git version
 try:
@@ -476,8 +432,7 @@ with open(out_dir / "git.json", "w") as f:
     json.dump(git_info, f)
 # Catalog command line arguments
 parser.save(args, out_dir / "args.json", format="json", skip_none=False)
-if rank == 0:
-    print(f"\nWriting output(s) to {out_dir.absolute()}", end="\n\n")
+print(f"\nWriting output(s) to {out_dir.absolute()}", end="\n\n")
 
 # Run Gibbs sampler
 # signal_cr = (Niter, Ntimes, Nfreqs) [complex]
@@ -488,8 +443,8 @@ start = time.time()
 signal_cr, signal_S, signal_ps, fg_amps, chisq, ln_post = \
     hp.pspec.gibbs_sample_with_fg(
         d,
-        w[0],  # FIXME
-        S_initial,
+        ~flags[0],  # FIXME: add functionality for time-dependent flags
+        sigcov0,
         fgmodes,
         Ninv,
         ps_prior,
@@ -497,32 +452,10 @@ signal_cr, signal_S, signal_ps, fg_amps, chisq, ln_post = \
         seed=args.seed,
         map_estimate=args.map_estimate,
         verbose=args.verbose,
-        nproc=nproc,
+        nproc=args.Nproc,
         write_Niter=args.write_Niter,
         out_dir=out_dir
     )
+print(f"Sampling complete!", end="\n\n")
 elapsed = time.time() - start
-
-# samples = {
-#     "signal_cr": signal_cr,
-#     "signal_S": signal_S,
-#     "signal_ps": signal_ps,
-#     "fg_amps": fg_amps,
-#     "chisq": chisq,
-#     "ln_post": ln_post,
-#     "elapsed": elapsed
-# }
-# data = (bl, samples)
-
-# # Gather results from all baselines
-# data = comm.gather(data, root=0)
-# if rank == 0:
-#     data = dict(data)
-#     times = [data[bl_key]["elapsed"] for bl_key in data]
-#     times_avg = np.mean(times) * units.s
-#     if times_avg.value > 3600:
-#         times_avg = times_avg.to("h")
-#     elif times_avg.value > 60:
-#         times_avg = times_avg.to("min")
-#     print(f"Average evaluation time for {args.Niter} iterations: {times_avg}")
-
+print(f"Time elapsed: {elapsed} s")


### PR DESCRIPTION
This pull request is work done in preparation of #11 and contains the following changes:

1. Removes the MPI parallelization over the baseline axis in the driver script `hydra-pspec/run-hydra-pspec.py`
2. Congregates some of the logic in setting up metadata (noise, flags, etc.) to make the code easier to follow
3. Introduces a change to the FG model command line argument from `--fg_eig_dir` and `--fg_eig_file` --> `--fgmodes` and `--fgmodes_file`.  Now, `--fgmodes` can specify either a file or a path to a directory containing subdirectories for each baseline with a filename matching `--fgmodes_file` in each subdirectory.  The help strings for these command line arguments have been adjusted accordingly.
4. Adds a temporary fix for #8 which only writes to disk the samples drawn up to the given iteration.  This data writing process can still be improved (e.g. appending to a text file instead of re-writing samples multiple times), but I don't know if I/O is a current bottleneck.

I ran a test of the code after all of these changes on the test data (to be provided in a future PR) and the results are comparable to those obtained with the test data before the changes.