### PR TITLE
Add script to write jobscripts

### DIFF
--- a/create_jobscript.sh
+++ b/create_jobscript.sh
@@ -1,0 +1,7 @@
+# Script to create slurm jobscripts for run-hydra-pspec.py with different numbers of ranks
+# Usage:
+# bash create_jobscript.sh number_of_ranks
+
+n_ranks=$1
+job_name="strongscaling_${n_ranks}ranks"
+sed "s/n_ranks_placeholder/${n_ranks}/g; s/job_name_placeholder/${job_name}/g" jobscript.sh.template > jobscript_${job_name}.sh

--- a/create_jobscript.sh
+++ b/create_jobscript.sh
@@ -8,4 +8,4 @@ n_baselines=3
 results_dir=strong_scaling_results
 sed "s/n_ranks/${n_ranks}/g; s/job_name/${job_name}/g; s/out_dir/${results_dir}/g" \
     jobscript.sh.template > jobscript_${job_name}.sh
-mkdir -p ${results_dir}/slurm-logs
+mkdir -p slurm-logs

--- a/create_jobscript.sh
+++ b/create_jobscript.sh
@@ -4,4 +4,8 @@
 
 n_ranks=$1
 job_name="strongscaling_${n_ranks}ranks"
-sed "s/n_ranks_placeholder/${n_ranks}/g; s/job_name_placeholder/${job_name}/g" jobscript.sh.template > jobscript_${job_name}.sh
+n_baselines=3
+results_dir=strong_scaling_results
+sed "s/n_ranks/${n_ranks}/g; s/job_name/${job_name}/g; s/out_dir/${results_dir}/g" \
+    jobscript.sh.template > jobscript_${job_name}.sh
+mkdir -p ${results_dir}/slurm-logs

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -1,0 +1,5 @@
+# Script to run run-hydra-pspec.py with different numbers of ranks
+nranks=$1
+results_dir="temp/3bl_${nranks}ranks"
+mpirun -n ${nranks} python run-hydra-pspec.py --config config-3bl-mpi.yaml --dirname=${results_dir}
+cp $0 ${results_dir}

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -1,5 +1,0 @@
-# Script to run run-hydra-pspec.py with different numbers of ranks
-nranks=$1
-results_dir="temp/3bl_${nranks}ranks"
-mpirun -n ${nranks} python run-hydra-pspec.py --config config-3bl-mpi.yaml --dirname=${results_dir}
-cp $0 ${results_dir}

--- a/jobscript.sh.template
+++ b/jobscript.sh.template
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --ntasks n_ranks_placeholder
+#SBATCH --time 30:00
+#SBATCH --mem 64G
+#SBATCH --job-name job_name_placeholder
+#SBATCH --partition cosma8-serial
+#SBATCH --account dp270
+#SBATCH --output=R-%x.%j.out
+#SBATCH --error=R-%x.%j.err
+
+module purge
+module load intel_comp/2020-update2
+module load intel_mpi/2020-update2
+
+source ~/.bashrc
+source .venv/bin/activate
+which python
+
+script="/cosma/home/dp270/dc-cape1/hydra-pspec/run-hydra-pspec.py"
+results_dir="strong_scaling/3bl_${SLURM_NTASKS}ranks"
+args="--config config-3bl-mpi.yaml --dirname=${results_dir}"
+
+mpirun -n $SLURM_NTASKS python -u $script $args
+cp $0 ${results_dir}
+

--- a/jobscript.sh.template
+++ b/jobscript.sh.template
@@ -6,8 +6,8 @@
 #SBATCH --job-name job_name
 #SBATCH --partition cosma8-serial
 #SBATCH --account dp270
-#SBATCH --output=out_dir/slurm-logs/%x.%j.out
-#SBATCH --error=out_dir/slurm-logs/%x.%j.err
+#SBATCH --output=slurm-logs/%x.%j.out
+#SBATCH --error=slurm-logs/%x.%j.err
 
 module purge
 module load intel_comp/2020-update2

--- a/jobscript.sh.template
+++ b/jobscript.sh.template
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-#SBATCH --ntasks n_ranks_placeholder
+#SBATCH --ntasks n_ranks
 #SBATCH --time 30:00
 #SBATCH --mem 64G
-#SBATCH --job-name job_name_placeholder
+#SBATCH --job-name job_name
 #SBATCH --partition cosma8-serial
 #SBATCH --account dp270
-#SBATCH --output=R-%x.%j.out
-#SBATCH --error=R-%x.%j.err
+#SBATCH --output=out_dir/slurm-logs/%x.%j.out
+#SBATCH --error=out_dir/slurm-logs/%x.%j.err
 
 module purge
 module load intel_comp/2020-update2
@@ -18,7 +18,7 @@ source .venv/bin/activate
 which python
 
 script="/cosma/home/dp270/dc-cape1/hydra-pspec/run-hydra-pspec.py"
-results_dir="strong_scaling/3bl_${SLURM_NTASKS}ranks"
+results_dir="out_dir/3bl_n_ranksranks"
 args="--config config-3bl-mpi.yaml --dirname=${results_dir}"
 
 mpirun -n $SLURM_NTASKS python -u $script $args

--- a/plot_speed_up.py
+++ b/plot_speed_up.py
@@ -2,7 +2,7 @@
 Plot speed up for fixed problem size, varying number of baselines/rank.
 Usage:
 python plot_speed_up.py --results_dir=dir_containing_multiple_runs_as_subdirs
-python plots_speed_up.py --summary_file=file_containing_timings_from_all_runs.json
+python plot_speed_up.py --summary_file=file_containing_timings_from_all_runs.json
 """
 
 import argparse
@@ -35,6 +35,7 @@ if args.results_dir:
 if args.summary_file:
     with open(Path(args.summary_file).resolve()) as f:
         timings = json.load(f)
+    results_dir = Path(args.summary_file).parent.resolve()
 
 
 def process_data(data: list[dict], timer: str):
@@ -61,7 +62,7 @@ def plot_speed_up(speed_up: list, x: list):
     ax.set_xlabel("Baselines/rank")
     ax.xaxis.set_inverted(True)
     plt.legend()
-    plt.show()
+    plt.savefig(results_dir.joinpath("speed_up.pdf"))
 
 
 speed_up, bl_per_rank = process_data(timings, "total")

--- a/run-hydra-pspec.py
+++ b/run-hydra-pspec.py
@@ -351,9 +351,9 @@ if rank == 0:
     except:
         git_info = ''
     with open(out_dir / "git.json", "w") as f:
-        json.dump(git_info, f)
+        json.dump(git_info, f, indent=2)
     # Catalog command line arguments
-    parser.save(args, out_dir / "args.json", format="json", skip_none=False)
+    parser.save(args, out_dir / "args.json", format="json_indented", skip_none=False)
     if "SLURM_JOB_ID" in os.environ:
         # If running in SLURM, create empty file named with the SLURM Job ID
         (out_dir / os.environ["SLURM_JOB_ID"]).touch()


### PR DESCRIPTION
This has only been tested on the 3 baselines we currently have but looks to work well.

Fix https://github.com/UoMResearchIT/hydra-mpi-issues/issues/34

- Create jobscript for the current 3 baseline problem size, with number of ranks given as a command line argument
- Copy the jobscript to the results directory