### PR TITLE
Restore original random seed behaviour

### DIFF
--- a/hydra_pspec/pspec.py
+++ b/hydra_pspec/pspec.py
@@ -139,7 +139,7 @@ def gcr_fgmodes_1d(
     # WARNING: if more than 1000 processes is every used this sum will not
     # guarantee a unique seed for each process!
     pid = current_process().pid
-    seed = multiprocess_seed + idx
+    seed = multiprocess_seed + pid*1000 + idx
     np.random.seed(seed)
 
     Nfreqs, Nmodes = fgmodes.shape


### PR DESCRIPTION
This is the original random seed code before fixing it for the scaling tests.
So just putting it back to how it was, but I think this should still be reviewed as part of https://github.com/UoMResearchIT/hydra-mpi-issues/issues/28